### PR TITLE
fix translation conflict & 'losses' spelling

### DIFF
--- a/scripting/include/kento_rankme/cmds.inc
+++ b/scripting/include/kento_rankme/cmds.inc
@@ -1475,7 +1475,7 @@ public void SQL_StatsMe2Callback(Handle owner, Handle hndl, const char[] error, 
 
 	Format(temp,sizeof(temp),"- %T\n","RoundStats",client);
 	StrCat(text,255,temp);
-	Format(temp,255,"%T: %d/%d   %T: %d/%d   %T: %d\n%T: %d   %T: %d   %T: %d\n","TRWins",client,SQL_FetchInt(hndl,68),SQL_FetchInt(hndl,14),"CTWins",client,SQL_FetchInt(hndl,67),SQL_FetchInt(hndl,15),"MVPs",client,SQL_FetchInt(hndl,73), "Match Wins", client, SQL_FetchInt(hndl, 75), "Match Draws", client, SQL_FetchInt(hndl, 76), "Match Loses", client, SQL_FetchInt(hndl, 77));
+	Format(temp,255,"%T: %d/%d   %T: %d/%d   %T: %d\n%T: %d   %T: %d   %T: %d\n","TRWins",client,SQL_FetchInt(hndl,68),SQL_FetchInt(hndl,14),"CTWins",client,SQL_FetchInt(hndl,67),SQL_FetchInt(hndl,15),"MVPs",client,SQL_FetchInt(hndl,73), "MatchWins", client, SQL_FetchInt(hndl, 75), "MatchDraws", client, SQL_FetchInt(hndl, 76), "MatchLosses", client, SQL_FetchInt(hndl, 77));
 	StrCat(text,255,temp);
 	panel.AddItem("",text);
 	text="";
@@ -1601,7 +1601,7 @@ public void SQL_StatsMeCallback(Handle owner, Handle hndl, const char[] error, a
 	
 	Format(temp,sizeof(temp),"- %T\n","RoundStats",client);
 	StrCat(text,255,temp);
-	Format(temp,255,"%T: %d/%d   %T: %d/%d   %T: %d\n%T: %d   %T: %d   %T: %d \n","TRWins",client,g_aStats[client][TR_WIN],g_aStats[client][ROUNDS_TR],"CTWins",client,g_aStats[client][CT_WIN],g_aStats[client][ROUNDS_CT],"MVPs",client,g_aStats[client][MVP], "Match Wins", client, g_aStats[client][MATCH_WIN], "Match Draws", client, g_aStats[client][MATCH_DRAW], "Match Loses", client, g_aStats[client][MATCH_LOSE]);
+	Format(temp,255,"%T: %d/%d   %T: %d/%d   %T: %d\n%T: %d   %T: %d   %T: %d \n","TRWins",client,g_aStats[client][TR_WIN],g_aStats[client][ROUNDS_TR],"CTWins",client,g_aStats[client][CT_WIN],g_aStats[client][ROUNDS_CT],"MVPs",client,g_aStats[client][MVP], "MatchWins", client, g_aStats[client][MATCH_WIN], "MatchDraws", client, g_aStats[client][MATCH_DRAW], "MatchLosses", client, g_aStats[client][MATCH_LOSE]);
 	StrCat(text,255,temp);
 	panel.AddItem("",text);
 	text="";

--- a/translations/chi/kento.rankme.phrases.txt
+++ b/translations/chi/kento.rankme.phrases.txt
@@ -642,17 +642,17 @@
 		"chi"		"伤害排名"
 	}
 	
-	"Match Wins"
+	"MatchWins"
 	{
 		"en"		"胜场"
 	}
 	
-	"Match Loses"
+	"MatchLosses"
 	{
 		"en"		"败场"
 	}
 	
-	"Match Draws"
+	"MatchDraws"
 	{
 		"en"		"平手"
 	}

--- a/translations/kento.rankme.phrases.txt
+++ b/translations/kento.rankme.phrases.txt
@@ -648,17 +648,17 @@
 		"en"		"TOP Damage"
 	}
 	
-	"Match Wins"
+	"MatchWins"
 	{
 		"en"		"Match Wins"
 	}
 	
-	"Match Loses"
+	"MatchLosses"
 	{
-		"en"		"Match Loses"
+		"en"		"Match Losses"
 	}
 	
-	"Match Draws"
+	"MatchDraws"
 	{
 		"en"		"Match Draws"
 	}

--- a/translations/pl/kento.rankme.phrases.txt
+++ b/translations/pl/kento.rankme.phrases.txt
@@ -602,16 +602,16 @@
 	{
 		"pl"		"TOP obrazenia"
 	}
-		"Match Wins"
+		"MatchWins"
 	{
 		"pl"		"Mecz wygrywa"
 	}
-	"Match Loses"
+	"MatchLosses"
 	{
 		"pl"		"Mecz przegrywa"
 	}
 	
-	"Match Draws"
+	"MatchDraws"
 	{
 		"pl"		"Mech zremisowany"
 	}

--- a/translations/zho/kento.rankme.phrases.txt
+++ b/translations/zho/kento.rankme.phrases.txt
@@ -648,17 +648,17 @@
 		"zho"		"傷害排名"
 	}
 	
-	"Match Wins"
+	"MatchWins"
 	{
 		"en"		"勝場"
 	}
 	
-	"Match Loses"
+	"MatchLosses"
 	{
 		"en"		"敗場"
 	}
 	
-	"Match Draws"
+	"MatchDraws"
 	{
 		"en"		"平手"
 	}


### PR DESCRIPTION
This fixes Chinese translations being displayed for English clients, as you can see here:
![Image](https://share.snksrv.com/i/14XCpA.png)

This is due to the Translation string & the actual language output being one and the same.

```
"Match Wins" > "MatchWins"
"Match Loses > "MatchLosses"
"Match Draws" > "MatchDraws"
```

Updated every language translation file to reflect this fix, along with fixing the english spelling of "Losses". Tested and working well:
![Image](https://share.snksrv.com/i/OCxoic.png)