### PR TITLE
Fix Memory Leak Issue #109

### DIFF
--- a/scripting/include/kento_rankme/cmds.inc
+++ b/scripting/include/kento_rankme/cmds.inc
@@ -1072,7 +1072,7 @@ public void SQL_RankCallback(Handle owner, Handle hndl, const char[] error, any 
 	while(SQL_HasResultSet(hndl) && SQL_FetchRow(hndl))
 	{
 		i++;
-		SQL_FetchString(hndl,2,Name_receive,MAX_NAME_LENGTH*2+1);
+		SQL_FetchString(hndl,2,Name_receive,MAX_NAME_LENGTH);
 		SQL_FetchString(hndl,1,Auth_receive,64);
 		SQL_FetchString(hndl,3,Ip_receive,64);
 	//	PrintToServer("%d %s %s",i, Name_receive, Auth_receive);


### PR DESCRIPTION
Basically Name_receive was instantiated with MAX_NAME_LENGTH size and when fetching from the database it was trying to assign MAX_NAME_LENGTH * 2 size, which is greater than the initial size.

Thanks to deathknife for pointing out this.