### PR TITLE
Prevent minimum players to be reached by the unassigned team.

### DIFF
--- a/scripting/kento_rankme.sp
+++ b/scripting/kento_rankme.sp
@@ -434,7 +434,7 @@ int GetCurrentPlayers()
 {
 	int count;
 	for (int i = 1; i <= MaxClients; i++) {
-		if (IsClientInGame(i) && (!IsFakeClient(i) || g_bRankBots) && GetClientTeam(i) != CS_TEAM_SPECTATOR) {
+		if (IsClientInGame(i) && (!IsFakeClient(i) || g_bRankBots) && GetClientTeam(i) != CS_TEAM_SPECTATOR && GetClientTeam(i) != CS_TEAM_NONE) {
 			count++;
 		}
 	}


### PR DESCRIPTION
Unassigned is a different team in CS:GO, defined as CS_TEAM_NONE, meaning not in a team.

Didn't test the single line edit but no way it won't compile.