### PR TITLE
Add additional check for valid clients

### DIFF
--- a/scripting/kento_rankme.sp
+++ b/scripting/kento_rankme.sp
@@ -645,7 +645,7 @@ public Action Event_RoundMVP(Handle event, const char[] name, bool dontBroadcast
 		return;
 	
 	int client = GetClientOfUserId(GetEventInt(event, "userid"));
-	if (!IsClientInGame(client))
+	if (client < 1 || !IsClientInGame(client))
 		return;
 	int team = GetClientTeam(client);
 	


### PR DESCRIPTION
Sometimes IsClientInGame throws the following exception: `Client index 0 is invalid`. This can happen if the client is not found based on the userid, which means "0" will be returned from GetClientOfUserId. 0 is not a valid client though, so IsClientInGame does not like it.